### PR TITLE
More flexibility on Faraday's version to avoid version conflicts with other dependencies within a same project

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,7 @@ Style/Documentation:
 
 Metrics/LineLength:
   Max: 100
+
+Style/BlockLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.6
   - 2.2.2
   - 2.3.0
+  - 2.4.0
+  - 2.4.2
+  - 2.5.0-preview1
 before_install: gem install bundler -v 1.10.6
 script:
   - bundle exec rspec --fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.3.0
   - 2.4.0
   - 2.4.2
-  - 2.5.0-preview1
 before_install: gem install bundler -v 1.10.6
 script:
   - bundle exec rspec --fail-fast

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 

--- a/lib/slack/attachment.rb
+++ b/lib/slack/attachment.rb
@@ -2,9 +2,9 @@
 
 module Slack
   class Attachment
-    ATTRIBUTES = %i[
-      fallback text title title_link image_url thumb_url color pretext author
-      author_name author_link author_icon
+    ATTRIBUTES = [
+      :fallback, :text, :title, :title_link, :image_url, :thumb_url, :color, :pretext, :author,
+      :author_name, :author_link, :author_icon
     ].freeze
 
     ATTRIBUTES.each do |attribute|

--- a/lib/slack/attachment.rb
+++ b/lib/slack/attachment.rb
@@ -2,9 +2,9 @@
 
 module Slack
   class Attachment
-    ATTRIBUTES = [
-      :fallback, :text, :title, :title_link, :image_url, :thumb_url, :color, :pretext, :author,
-      :author_name, :author_link, :author_icon
+    ATTRIBUTES = %i[
+      fallback text title title_link image_url thumb_url color pretext author
+      author_name author_link author_icon
     ].freeze
 
     ATTRIBUTES.each do |attribute|

--- a/lib/slack/attachment.rb
+++ b/lib/slack/attachment.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module Slack
   class Attachment
-    ATTRIBUTES = [
-      :fallback, :text, :title, :title_link, :image_url, :thumb_url, :color, :pretext, :author,
-      :author_name, :author_link, :author_icon
+    ATTRIBUTES = %i[
+      fallback text title title_link image_url thumb_url color pretext author
+      author_name author_link author_icon
     ].freeze
 
     ATTRIBUTES.each do |attribute|

--- a/lib/slack/field.rb
+++ b/lib/slack/field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Slack
   class Field
     attr_accessor :title, :value, :short

--- a/lib/slack/message.rb
+++ b/lib/slack/message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Slack
   class Message
     attr_accessor :text

--- a/lib/slack/poster.rb
+++ b/lib/slack/poster.rb
@@ -13,7 +13,7 @@ module Slack
 
     # Define getters and setters for the options hash keys. This will make assign of the options
     # more flexible.
-    %i[username channel icon_url icon_emoji].each do |option_attr|
+    [:username, :channel, :icon_url, :icon_emoji].each do |option_attr|
       define_method(option_attr) { @options[option_attr] }
       define_method("#{option_attr}=") { |value| @options[option_attr] = value }
     end

--- a/lib/slack/poster.rb
+++ b/lib/slack/poster.rb
@@ -13,7 +13,7 @@ module Slack
 
     # Define getters and setters for the options hash keys. This will make assign of the options
     # more flexible.
-    [:username, :channel, :icon_url, :icon_emoji].each do |option_attr|
+    %i[username channel icon_url icon_emoji].each do |option_attr|
       define_method(option_attr) { @options[option_attr] }
       define_method("#{option_attr}=") { |value| @options[option_attr] = value }
     end

--- a/lib/slack/poster.rb
+++ b/lib/slack/poster.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'slack/version'
 require 'slack/field'
 require 'slack/message'
@@ -11,7 +13,7 @@ module Slack
 
     # Define getters and setters for the options hash keys. This will make assign of the options
     # more flexible.
-    [:username, :channel, :icon_url, :icon_emoji].each do |option_attr|
+    %i[username channel icon_url icon_emoji].each do |option_attr|
       define_method(option_attr) { @options[option_attr] }
       define_method("#{option_attr}=") { |value| @options[option_attr] = value }
     end

--- a/lib/slack/version.rb
+++ b/lib/slack/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Slack
-  VERSION = '2.2.0'.freeze
+  VERSION = '2.2.0'
 end

--- a/slack-poster.gemspec
+++ b/slack-poster.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.37', '> 0.35'
 
-  spec.add_runtime_dependency 'faraday', '~> 0.9.2'
+  spec.add_runtime_dependency 'faraday', '~> 0.9'
 end

--- a/slack-poster.gemspec
+++ b/slack-poster.gemspec
@@ -1,4 +1,6 @@
-# coding: utf-8
+
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
@@ -20,12 +22,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '> 1.10.0'
+  spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 10.4'
   spec.add_development_dependency 'rspec', '~> 3.4'
-  spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'webmock', '~> 1.22'
-  spec.add_development_dependency 'vcr', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.37', '> 0.35'
+  spec.add_development_dependency 'vcr', '~> 3.0'
+  spec.add_development_dependency 'webmock', '~> 1.22'
 
   spec.add_runtime_dependency 'faraday', '~> 0.9'
 end

--- a/slack-poster.gemspec
+++ b/slack-poster.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 10.4'
   spec.add_development_dependency 'rspec', '~> 3.4'
-  spec.add_development_dependency 'rubocop', '~> 0.37', '> 0.35'
+  spec.add_development_dependency 'rubocop', '~> 0.41.2'
   spec.add_development_dependency 'vcr', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 1.22'
 

--- a/slack-poster.gemspec
+++ b/slack-poster.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 10.4'
   spec.add_development_dependency 'rspec', '~> 3.4'
-  spec.add_development_dependency 'rubocop', '~> 0.41.2'
+  spec.add_development_dependency 'rubocop', '~> 0.37', '> 0.35'
   spec.add_development_dependency 'vcr', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 1.22'
 

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Slack::Attachment do

--- a/spec/field_spec.rb
+++ b/spec/field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Slack::Field do

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Slack::Message do

--- a/spec/poster_spec.rb
+++ b/spec/poster_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 # Ruby 1.9.3 needs to require securerandom
@@ -29,7 +31,7 @@ describe Slack::Poster do
     end
   end
 
-  [:username, :channel, :icon_url, :icon_emoji].each do |option_attr|
+  %i[username channel icon_url icon_emoji].each do |option_attr|
     describe "#{option_attr}=" do
       it "sets the #{option_attr} field in options hash" do
         poster.send("#{option_attr}=", "test_#{option_attr}")

--- a/spec/poster_spec.rb
+++ b/spec/poster_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-
-# Ruby 1.9.3 needs to require securerandom
-require 'securerandom' if RUBY_VERSION < '2.0.0'
+require 'securerandom'
 
 describe Slack::Poster do
   let(:hook) { ENV.fetch('SLACK_POSTER_TEST_WEBHOOK') }

--- a/spec/poster_spec.rb
+++ b/spec/poster_spec.rb
@@ -31,7 +31,7 @@ describe Slack::Poster do
     end
   end
 
-  %i[username channel icon_url icon_emoji].each do |option_attr|
+  [:username, :channel, :icon_url, :icon_emoji].each do |option_attr|
     describe "#{option_attr}=" do
       it "sets the #{option_attr} field in options hash" do
         poster.send("#{option_attr}=", "test_#{option_attr}")

--- a/spec/poster_spec.rb
+++ b/spec/poster_spec.rb
@@ -29,7 +29,7 @@ describe Slack::Poster do
     end
   end
 
-  [:username, :channel, :icon_url, :icon_emoji].each do |option_attr|
+  %i[username channel icon_url icon_emoji].each do |option_attr|
     describe "#{option_attr}=" do
       it "sets the #{option_attr} field in options hash" do
         poster.send("#{option_attr}=", "test_#{option_attr}")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 
 Bundler.require


### PR DESCRIPTION
Dropping patch level to allow faraday versions >= 0.9.0, < 1.0.0

Additionally, most rubocop offenses were corrected.